### PR TITLE
fix: use correct property for indent_style in [*]

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ root = true
 end_of_line = lf
 charset = utf-8
 insert_final_newline = true
-indent_style = tabs
+indent_style = tab
 indent_size = 4
 
 [*.txt]


### PR DESCRIPTION
Hi 👋 

I was wondering why my editor always ignored the indentation style.
Apparently it's "tab", not "tabs": https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#indent_style