### PR TITLE
docs: remove `(Optional)` from FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 3. Select `import theme` and browse to where you cloned Catppuccin
 4. Select it
 
+<!-- this section is optional -->
 ## 🙋 FAQ
 
 -	Q: **_"Where can I find the doc?"_**\

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 3. Select `import theme` and browse to where you cloned Catppuccin
 4. Select it
 
-## 🙋 FAQ (optional)
+## 🙋 FAQ
 
 -	Q: **_"Where can I find the doc?"_**\
 	A: Run `:help theme`


### PR DESCRIPTION
Some ports in the Catppuccin namespace haven't removed the `(Optional)` from the FAQ heading even when FAQ questions have been included.

This commit reduces the chance of that by removing it altogether. An empty FAQ section would still get deleted and if FAQ questions are included, the maintainer does not need to remove the `(Optional)` from the heading anymore.

## Existing Ports With Optional

- https://github.com/catppuccin/waybar#-faq-optional
- https://github.com/catppuccin/i3#-faq-optional
- https://github.com/catppuccin/go#-faq-optional
- https://github.com/catppuccin/hyprland#-faq-optional
- https://github.com/catppuccin/hexchat#-faq-optional