### PR TITLE
docs(README): remove `clone repository` from usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@
 
 ## Usage
 
-1. Download the flavor of your choice from [`themes/`](./themes/).
+1. Download the flavor of your choice.
 2. Open the app and go to **Preferences** > **Appearance** > **Import theme**.
-3. Select the theme file downloaded in Step 1.
+3. Select the downloaded flavor file.
 
 <!-- This section is optional. Uncomment the following if needed.
 

--- a/README.md
+++ b/README.md
@@ -36,16 +36,18 @@
 
 ## Usage
 
-1. Clone this repository locally
-2. Open the app's settings
-3. Select `import theme` and browse to where you cloned Catppuccin
-4. Select it
+1. Download the flavor of your choice from [`themes/`](./themes/).
+2. Open App's settings.
+3. Open the app and to **Preferences** > **Appearance** > **Import theme** and select the theme file downloaded in Step 1.
 
-<!-- this section is optional -->
+<!-- This section is optional. Uncomment the following if needed.
+
 ## 🙋 FAQ
 
--	Q: **_"Where can I find the doc?"_**\
-	A: Run `:help theme`
+- Q: **_"How can I do X?"_**\
+  A: ...
+
+-->
 
 ## 💝 Thanks to
 

--- a/README.md
+++ b/README.md
@@ -40,14 +40,11 @@
 2. Open the app and go to **Preferences** > **Appearance** > **Import theme**.
 3. Select the downloaded flavor file.
 
-<!-- This section is optional. Uncomment the following if needed.
-
+<!-- The FAQ section is optional. Remove if needed.-->
 ## 🙋 FAQ
 
 - Q: **_"How can I do X?"_**\
   A: ...
-
--->
 
 ## 💝 Thanks to
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@
 ## Usage
 
 1. Download the flavor of your choice from [`themes/`](./themes/).
-2. Open App's settings.
-3. Open the app and to **Preferences** > **Appearance** > **Import theme** and select the theme file downloaded in Step 1.
+2. Open the app and go to **Preferences** > **Appearance** > **Import theme**.
+3. Select the theme file downloaded in Step 1.
 
 <!-- This section is optional. Uncomment the following if needed.
 


### PR DESCRIPTION
I think these usage instructions more accurately represent the instructions for a real app, and they demonstrate some good practices: linking to the themes directory, using `**X** > **Y** > **Z**` for step by steps, etc. I also think commenting out the FAQ makes it more clear that that is the optional section that we are referring to, and makes it so maintainers don't feel "pressured" to add something random to fill it.